### PR TITLE
Fix invalid cast from juce::String to bool in Settings handling

### DIFF
--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -315,12 +315,13 @@ void SpeakerViewComponent::listenUDP()
                             });
                         }
                     } else if (property.compare(juce::String("keepSVTop")) == 0) {
-                        auto keepSVOnTopValue = static_cast<bool>(value);
+                 
+                        auto keepSVOnTopValue = value.isBool() ? static_cast<bool>(value) : value.toString().compareIgnoreCase("true") == 0;
                         juce::MessageManager::callAsync([this, keepSVOnTopValue] {
                             mMainContentComponent.handleKeepSVOnTopFromSpeakerView(keepSVOnTopValue);
                         });
                     } else if (property.compare(juce::String("showHall")) == 0) {
-                        auto showHallValue = static_cast<bool>(value);
+                        auto showHallValue = value.isBool() ? static_cast<bool>(value) : value.toString().compareIgnoreCase("true") == 0;
                         juce::MessageManager::callAsync([this, showHallValue] {
                             mMainContentComponent.handleShowHallFromSpeakerView(showHallValue);
                         });


### PR DESCRIPTION
Resolved type casting errors in `listenUDP()` by safely converting JUCE `var` values to bool. Updated both .cpp and .hpp files to handle values that might be either boolean or string ("true"/"false"). This prevents runtime errors when processing JSON settings like 'keepSVOnTop' and 'showHall'.