### PR TITLE
Add pulsed pink noise logic to PinkNoiseGenerator

### DIFF
--- a/Source/sg_PinkNoiseGenerator.cpp
+++ b/Source/sg_PinkNoiseGenerator.cpp
@@ -41,10 +41,21 @@ void fillWithPinkNoise(float * const * samples, int const numSamples, int const 
 {
     static constexpr auto FAC{ 1.0f / (static_cast<float>(RAND_MAX) / 2.0f) };
     static constexpr dbfs_t CORRECTION_DB{ -18.2f };
+    static int pulseCounter = 0;
+    static constexpr int SAMPLE_RATE = 48000;
+    static constexpr int PULSE_INTERVAL = SAMPLE_RATE; // 1 second
+    static bool pulseOn = true;
+
 
     static auto const CORRECTION{ CORRECTION_DB.toGain() };
 
-    for (int sampleIndex{}; sampleIndex < numSamples; ++sampleIndex) {
+    for (int sampleIndex{}; sampleIndex < numSamples; ++sampleIndex)
+         {
+           ++pulseCounter;
+          if (pulseCounter >= PULSE_INTERVAL) {
+        pulseOn = !pulseOn;
+       pulseCounter = 0;
+       } 
         auto const rnd{ narrow<float>(rand()) * FAC - 1.0f };
         pinkNoiseC0 = pinkNoiseC0 * 0.99886f + rnd * 0.0555179f;
         pinkNoiseC1 = pinkNoiseC1 * 0.99332f + rnd * 0.0750759f;
@@ -57,9 +68,12 @@ void fillWithPinkNoise(float * const * samples, int const numSamples, int const 
         sampleValue *= gain * CORRECTION;
         pinkNoiseC6 = rnd * 0.115926f;
 
-        for (int channelIndex{}; channelIndex < numChannels; channelIndex++) {
-            samples[channelIndex][sampleIndex] += sampleValue;
-        }
+       if (pulseOn) {
+         for (int channelIndex{}; channelIndex < numChannels; channelIndex++) {
+             samples[channelIndex][sampleIndex] += sampleValue;
+             }
+          }
+
     }
 }
 


### PR DESCRIPTION
Introduced a pulse toggle that switches pink noise on/off every 1 second (PULSE_INTERVAL). This was done by adding a pulse counter and conditional noise application.
Modified the fillWithPinkNoise function in sg_PinkNoiseGenerator.cpp to introduce pulsed behavior for the generated pink noise.

Key changes:
- Added a pulseOn boolean flag and a pulseCounter integer to control the toggling of the noise output.
- Introduced a PULSE_INTERVAL constant to define the number of samples after which the noise toggles on/off.
- Within the sample generation loop, pulseCounter is incremented with each sample.
- When pulseCounter exceeds PULSE_INTERVAL, pulseOn is toggled and the counter is reset.
- Pink noise is added to the output samples only when pulseOn is true, effectively creating a pulsed or gated pink noise effect.

This change enables the simulation of "pulsed" pink noise, useful for testing spatial behaviors or intermittent audio effects.

No changes were made to the header file (sg_PinkNoiseGenerator.hpp), as function signatures remain the same.
