### PR TITLE
Replace continuous pink noise with pulsed pink noise in speaker output

### DIFF
--- a/Source/sg_AudioProcessor.cpp
+++ b/Source/sg_AudioProcessor.cpp
@@ -129,7 +129,8 @@ void AudioProcessor::processAudio(SourceAudioBuffer & sourceBuffer,
             activeChannels.push_back(channel.key);
         }
         auto data{ speakerBuffer.getArrayOfWritePointers(activeChannels) };
-        fillWithPinkNoise(data.data(), numSamples, narrow<int>(data.size()), *mAudioData.config->pinkNoiseGain);
+        fillWithPulsedPinkNoise(data.data(), numSamples, narrow<int>(data.size()), *mAudioData.config->pinkNoiseGain, pulseInterval, pulseLength);
+
     } else {
         // Process spat algorithm
         mSpatAlgorithm->process(*mAudioData.config, sourceBuffer, speakerBuffer, stereoBuffer, sourcePeaks, nullptr);


### PR DESCRIPTION
This commit updates the pink noise generation logic in `AudioProcessor::processAudio` by modifying a single line that previously called `fillWithPinkNoise(...)`. The new implementation introduces pulsed pink noise, which plays bursts of pink noise separated by silence, rather than a continuous signal.

This change is intended to address issue #452: "Remplacer le Reference Pink Noise de Speaker Edition Window, par un bruit rose pulsé". It improves the clarity of reference noise in speaker calibration and avoids masking effects caused by continuous noise.

Further enhancements can include exposing pulse parameters (interval, duration) through the GUI.